### PR TITLE
Change Git clone address

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ First, get the source code.
 
 .. sourcecode :: sh
 
-  git clone git@github.com:ascoderu/opwen-webapp.git
+  git clone https://github.com/ascoderu/opwen-webapp.git
   cd opwen-webapp
 
 Second, install the system-level dependencies using your package manager,


### PR DESCRIPTION
I was unable to clone with Git using the git@github.com:ascoderu/opwen-webapp.git address. https://github.com/ascoderu/opwen-webapp.git worked instead.