### PR TITLE
Issue 157 - Added resizing of images attached to emails

### DIFF
--- a/opwen_email_client/webapp/config.py
+++ b/opwen_email_client/webapp/config.py
@@ -14,9 +14,11 @@ env.read_env(settings_path, recurse=False)
 app_basedir = path.abspath(path.dirname(__file__))
 root_domain = env('OPWEN_ROOT_DOMAIN', 'lokole.ca')
 
+
 class ImageDimensions(object):
     MAX_WIDTH_IMAGES = env.int('LOKOLE_MAX_WIDTH_EMAIL_IMAGES', 200)
     MAX_HEIGHT_IMAGES = env.int('LOKOLE_MAX_HEIGHT_EMAIL_IMAGES', 200)
+
 
 # noinspection PyPep8Naming
 class i8n(object):

--- a/opwen_email_client/webapp/config.py
+++ b/opwen_email_client/webapp/config.py
@@ -14,6 +14,9 @@ env.read_env(settings_path, recurse=False)
 app_basedir = path.abspath(path.dirname(__file__))
 root_domain = env('OPWEN_ROOT_DOMAIN', 'lokole.ca')
 
+class ImageDimensions(object):
+    MAX_WIDTH_IMAGES = env.int('LOKOLE_MAX_WIDTH_EMAIL_IMAGES', 200)
+    MAX_HEIGHT_IMAGES = env.int('LOKOLE_MAX_HEIGHT_EMAIL_IMAGES', 200)
 
 # noinspection PyPep8Naming
 class i8n(object):

--- a/opwen_email_client/webapp/config.py
+++ b/opwen_email_client/webapp/config.py
@@ -15,6 +15,7 @@ app_basedir = path.abspath(path.dirname(__file__))
 root_domain = env('OPWEN_ROOT_DOMAIN', 'lokole.ca')
 
 
+# noinspection PyPep8Naming
 class ImageDimensions(object):
     MAX_WIDTH_IMAGES = env.int('LOKOLE_MAX_WIDTH_EMAIL_IMAGES', 200)
     MAX_HEIGHT_IMAGES = env.int('LOKOLE_MAX_HEIGHT_EMAIL_IMAGES', 200)

--- a/opwen_email_client/webapp/forms/email.py
+++ b/opwen_email_client/webapp/forms/email.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from datetime import datetime
 from io import BytesIO
 from itertools import chain

--- a/opwen_email_client/webapp/forms/email.py
+++ b/opwen_email_client/webapp/forms/email.py
@@ -1,13 +1,18 @@
+from copy import deepcopy
 from datetime import datetime
+from io import BytesIO
 from itertools import chain
+from mimetypes import guess_type
 from typing import Iterable
 from typing import List
 from typing import Optional
+from typing import Tuple
 
 from flask import render_template
 from flask import request
 from flask_login import current_user
 from flask_wtf import FlaskForm
+from PIL import Image
 from werkzeug.datastructures import FileStorage
 from wtforms import FileField
 from wtforms import SelectMultipleField
@@ -21,6 +26,7 @@ from opwen_email_client.util.wtforms import Emails
 from opwen_email_client.util.wtforms import HtmlTextAreaField
 from opwen_email_client.webapp.config import AppConfig
 from opwen_email_client.webapp.config import i8n
+from opwen_email_client.webapp.config import ImageDimensions
 
 
 class NewEmailForm(FlaskForm):
@@ -215,8 +221,45 @@ def _attachments_as_dict(filestorages: Iterable[FileStorage]) \
     for filestorage in filestorages:
         filename = filestorage.filename
         content = filestorage.stream.read()
-        if filename and content:
-            yield {'filename': filename, 'content': content}
+
+        formatted_content = _format_attachment(filename, content)
+
+        if filename and formatted_content:
+            yield {'filename': filename, 'content': formatted_content}
+
+
+def _format_attachment(filename: str, content: bytes) -> bytes:
+    attachment_type = guess_type(filename)[0]
+
+    if not attachment_type:
+        return content
+
+    if 'image' in attachment_type.lower():
+        content = _change_image_size(content)
+
+    return content
+
+
+def _is_already_small(size: Tuple[int, int]) -> bool:
+    width, height = size
+    return width <= ImageDimensions.MAX_WIDTH_IMAGES and height <= ImageDimensions.MAX_HEIGHT_IMAGES
+
+
+def _change_image_size(image_content_bytes: bytes) -> bytes:
+    image_bytes = BytesIO(image_content_bytes)
+    image_bytes.seek(0)
+    image = Image.open(image_bytes)
+
+    if _is_already_small(image.size):
+        return image_content_bytes
+
+    new_size = (ImageDimensions.MAX_WIDTH_IMAGES, ImageDimensions.MAX_HEIGHT_IMAGES)
+    image.thumbnail(new_size, Image.ANTIALIAS)
+    new_image = BytesIO()
+    image.save(new_image, image.format)
+    new_image.seek(0)
+    new_image_bytes = new_image.read()
+    return new_image_bytes
 
 
 def _is_local_message(address: str) -> bool:

--- a/opwen_email_client/webapp/forms/email.py
+++ b/opwen_email_client/webapp/forms/email.py
@@ -24,8 +24,8 @@ from opwen_email_client.domain.email.store import EmailStore
 from opwen_email_client.util.wtforms import Emails
 from opwen_email_client.util.wtforms import HtmlTextAreaField
 from opwen_email_client.webapp.config import AppConfig
-from opwen_email_client.webapp.config import i8n
 from opwen_email_client.webapp.config import ImageDimensions
+from opwen_email_client.webapp.config import i8n
 
 
 class NewEmailForm(FlaskForm):

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ typing==3.7.4.1
 tzlocal==2.0.0
 watchdog==0.9.0
 xtarfile[zstd]==0.0.2
+Pillow==6.2.1


### PR DESCRIPTION
I have utilized the code from the opwen-cloudserver to add image-resizing capability to the opwen-webapp. I added a new class to the config file for the image dimensions. I was unsure if you would prefer them to be individual variables similar to the opwen-cloudserver config file or bundled together in a class. I have tested the code with a single large image, multiple large images and smaller images. It successfully resized only the larger images in these cases. I left the maximum dimensions at 200 x 200, this can obviously be changed in the config file if it is desired to be larger.